### PR TITLE
[Fix] useOptimisticToggle: Include all Testcases

### DIFF
--- a/src/useOptimisticToggle.test.js
+++ b/src/useOptimisticToggle.test.js
@@ -35,7 +35,7 @@ describe('Test useOptimisticToggle()', () => {
     promise = null;
   });
 
-  it.only('stay checked when action succeeds', () => {
+  it('stay checked when action succeeds', () => {
     expect(wrapper.prop('checked')).toEqual(false);
     wrapper.simulate('change');
     expect(wrapper.prop('checked')).toEqual(true);


### PR DESCRIPTION
One testcase was marked as `only`, hence other testcases were being skipped.
Now all testcase should be tested against.

Signed-off-by: Progyan Bhattacharya <progyan@hackerrank.com>