### PR TITLE
[Refactor] Utility: Extract noop methods to util

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-optimistic-toggle",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "React component to build Optimistic UIs.",
   "main": "lib/OptimisticToggle.js",
   "repository": "https://github.com/interviewstreet/react-optimistic-toggle.git",

--- a/src/OptimisticToggle.js
+++ b/src/OptimisticToggle.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Component, SyntheticEvent } from 'react';
 
-const noop = () => {};
+import { noop, noopPromise } from './util';
 
 type Props = {
   /** Initial Value of the Checkbox */
@@ -19,7 +19,7 @@ type State = {
 class OptimisticToggle extends Component<Props, State> {
   static defaultProps: Props = {
     initialValue: false,
-    action: noop,
+    action: noopPromise,
     children: noop,
   };
 

--- a/src/useOptimisticToggle.js
+++ b/src/useOptimisticToggle.js
@@ -1,6 +1,6 @@
 import { useState, useRef, SyntheticEvent } from 'react';
 
-const noop = () => {};
+import { noopPromise } from './util';
 
 type Props = {
   /** Initial Value of the Checkbox */
@@ -9,7 +9,7 @@ type Props = {
   action?: (toggleState: boolean, event: SyntheticEvent) => Promise<any>,
 };
 
-function useOptimisticToggle({ initialValue = false, action = noop }: Props) {
+function useOptimisticToggle({ initialValue = false, action = noopPromise }: Props) {
   const [stateOptimistic, setStateOptimistic] = useState(initialValue);
   const refCurrentPromise = useRef();
   const refFailedCount = useRef(0);

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,10 @@
+/* istanbul ignore next */
+export function noop() {
+  /** No Operation */
+}
+
+/* istanbul ignore next */
+export function noopPromise() {
+  /** No Operation that Returns a Promise */
+  return Promise.resolve();
+}


### PR DESCRIPTION
Create two utility functions one returning empty Promise object and one returning void to use as default props for the component and HoC.

Signed-off-by: Progyan Bhattacharya <progyan@hackerrank.com>